### PR TITLE
Batch claim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 *.pyc
 /.hypothesis
+
+*.swp
+*.swo

--- a/contracts/BatchClaimer.vy
+++ b/contracts/BatchClaimer.vy
@@ -17,8 +17,4 @@ def claim_all(user: address, splitters: DynArray[address, 10], use_vest:bool = T
         if i >= len(splitters):
             break
         splitter: address = splitters[i]
-        if splitter == empty(address):
-            continue
-        if VestSplitter(splitter).balanceOf(user, use_vest) == 0:
-            continue
         VestSplitter(splitter).claim(user, use_vest)

--- a/contracts/BatchClaimer.vy
+++ b/contracts/BatchClaimer.vy
@@ -1,0 +1,24 @@
+# @version 0.3.10
+"""
+@title BatchClaimer
+@author Curve DAO
+@license MIT
+@notice Allows claiming from multiple splitters in one transaction for a single user.
+"""
+
+interface VestSplitter:
+    def claim(user: address, use_vest: bool = True): nonpayable
+    def balanceOf(user: address, use_vest: bool = True) -> uint256: view
+
+
+@external
+def claim_all(user: address, splitters: DynArray[address, 10], use_vest:bool = True):
+    for i in range(10):
+        if i >= len(splitters):
+            break
+        splitter: address = splitters[i]
+        if splitter == empty(address):
+            continue
+        if VestSplitter(splitter).balanceOf(user, use_vest) == 0:
+            continue
+        VestSplitter(splitter).claim(user, use_vest)

--- a/scripts/deploy_batch_claimer.py
+++ b/scripts/deploy_batch_claimer.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import sys
+import boa
+
+NETWORK = "http://localhost:8545"
+
+def account_load(fname):
+    path = os.path.expanduser(os.path.join('~', '.brownie', 'accounts', fname + '.json'))
+    with open(path, 'r') as f:
+        pkey = account.decode_keyfile_json(json.load(f), getpass())
+        return account.Account.from_key(pkey)
+
+if __name__ == '__main__':
+    if '--fork' in sys.argv[1:]:
+        boa.env.fork(NETWORK)
+        boa.env.eoa = '0xbabe61887f1de2713c6f97e567623453d3C79f67'
+    else:
+        boa.set_env(NetworkEnv(NETWORK))
+        if not is_verify:
+            boa.env.add_account(account_load('babe'))
+        boa.env._fork_try_prefetch_state = False
+
+    batch_claimer = boa.load("contracts/BatchClaimer.vy")
+    print(f"Deployed the batch claimer at: {batch_claimer.address}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,12 @@ def splitter(token, admin):
 
 
 @pytest.fixture(scope="session")
+def splitter_2(token, admin):
+    with boa.env.prank(admin):
+        return boa.load('contracts/VestSplitter.vy', token.address)
+
+
+@pytest.fixture(scope="session")
 def vesting_escrow(token, accounts, splitter, admin):
     with boa.env.prank(admin):
         escrow = boa.load('contracts/testing/VestingEscrowSimple.vy')
@@ -50,6 +56,19 @@ def vesting_escrow(token, accounts, splitter, admin):
         token.approve(escrow.address, 2**256 - 1)
         escrow.initialize(
             admin, token.address, splitter.address, INITIAL_AMOUNT,
+            t0, t0 + DISTRIBUTION_TIME, False)
+        return escrow
+
+
+@pytest.fixture(scope="session")
+def vesting_escrow_2(token, accounts, splitter_2, admin):
+    with boa.env.prank(admin):
+        escrow = boa.load('contracts/testing/VestingEscrowSimple.vy')
+        t0 = boa.env.vm.patch.timestamp
+        token._mint_for_testing(admin, 10**8 * 10**18)
+        token.approve(escrow.address, 2**256 - 1)
+        escrow.initialize(
+            admin, token.address, splitter_2.address, INITIAL_AMOUNT,
             t0, t0 + DISTRIBUTION_TIME, False)
         return escrow
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,3 +52,8 @@ def vesting_escrow(token, accounts, splitter, admin):
             admin, token.address, splitter.address, INITIAL_AMOUNT,
             t0, t0 + DISTRIBUTION_TIME, False)
         return escrow
+
+
+@pytest.fixture(scope="session")
+def batch_claimer():
+    return boa.load("contracts/BatchClaimer.vy")

--- a/tests/test_batch_claim.py
+++ b/tests/test_batch_claim.py
@@ -1,17 +1,21 @@
 import boa
 
-def test_claim_all(batch_claimer, splitter, vesting_escrow, token, accounts, admin):
+def test_claim_all(batch_claimer, splitter, splitter_2, vesting_escrow, vesting_escrow_2, token, accounts, admin):
+    splitters = [splitter, splitter_2]
+    escrows = [vesting_escrow, vesting_escrow_2]
+
     with boa.env.prank(admin):
-        splitter.set_vest(vesting_escrow.address)
+        for s, e in zip(splitters, escrows):
+            s.set_vest(e.address)
 
     user = accounts[0]
     with boa.env.prank(admin):
-        splitter.save_distribution([user], [10**18])
-        splitter.finalize_distribution()
+        for s in splitters:
+            s.save_distribution([user], [10**18])
+            s.finalize_distribution()
 
     boa.env.time_travel(366 * 86400)
 
     with boa.env.prank(user):
-        # splitter.claim()
-        batch_claimer.claim_all(user, [splitter.address])
-        assert token.balanceOf(user) == 10**8 * 10**18
+        batch_claimer.claim_all(user, [s.address for s in splitters])
+    assert token.balanceOf(user) == 2 * 10**8 * 10**18

--- a/tests/test_batch_claim.py
+++ b/tests/test_batch_claim.py
@@ -1,0 +1,17 @@
+import boa
+
+def test_claim_all(batch_claimer, splitter, vesting_escrow, token, accounts, admin):
+    with boa.env.prank(admin):
+        splitter.set_vest(vesting_escrow.address)
+
+    user = accounts[0]
+    with boa.env.prank(admin):
+        splitter.save_distribution([user], [10**18])
+        splitter.finalize_distribution()
+
+    boa.env.time_travel(366 * 86400)
+
+    with boa.env.prank(user):
+        # splitter.claim()
+        batch_claimer.claim_all(user, [splitter.address])
+        assert token.balanceOf(user) == 10**8 * 10**18

--- a/tests/test_batch_claim.py
+++ b/tests/test_batch_claim.py
@@ -1,21 +1,25 @@
 import boa
 
 def test_claim_all(batch_claimer, splitter, splitter_2, vesting_escrow, vesting_escrow_2, token, accounts, admin):
+    user = accounts[0]
+    user_2 = accounts[1]
     splitters = [splitter, splitter_2]
     escrows = [vesting_escrow, vesting_escrow_2]
+    distributions = [
+        [10**18, 10**18],
+        [10**18, 0],
+    ]
 
     with boa.env.prank(admin):
-        for s, e in zip(splitters, escrows):
-            s.set_vest(e.address)
-
-    user = accounts[0]
-    with boa.env.prank(admin):
-        for s in splitters:
-            s.save_distribution([user], [10**18])
-            s.finalize_distribution()
+        for _splitter, escrow, distribution in zip(splitters, escrows, distributions):
+            _splitter.set_vest(escrow.address)
+            _splitter.save_distribution([user, user_2], distribution)
+            _splitter.finalize_distribution()
 
     boa.env.time_travel(366 * 86400)
 
-    with boa.env.prank(user):
-        batch_claimer.claim_all(user, [s.address for s in splitters])
-    assert token.balanceOf(user) == 2 * 10**8 * 10**18
+    batch_claimer.claim_all(user, [s.address for s in splitters])
+    assert token.balanceOf(user) == 5*10**7 * 10**18 + 10**8 * 10**18
+
+    batch_claimer.claim_all(user_2, [s.address for s in splitters])
+    assert token.balanceOf(user_2) == 5*10**7 * 10**18


### PR DESCRIPTION
This is a helper for a frontend UI so only one transaction
needs to be dealt with.

The splitter contract allows anyone to claim for another,
so the logic is very simple: loop through given splitters and
call `claim` for the specified user.